### PR TITLE
Switching to the new MSI package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,7 @@ jobs:
           refreshenv
 
       - name: Podman Version
-        run: |
-          refreshenv 
-          podman --version
-        shell: pwsh
+        run: podman --version
 
   push:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - 'main'
 
 env:
-  VERSION: '5.8.1'
+  VERSION: '5.8.2'
 
 jobs:
   pack:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
           args: install podman-cli --version ${{ env.VERSION }} --source=.
 
       - name: Podman Version
-        run: podman --version
+        run: |
+          refreshenv 
+          podman --version
+        shell: pwsh
 
   push:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,12 @@ jobs:
         with:
           args: install podman-cli --version ${{ env.VERSION }} --source=.
 
-      - name: Refresh env
+      - name: Podman Version
         shell: pwsh
         run: |
           Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
           refreshenv
-
-      - name: Podman Version
-        run: podman --version
+          podman --version
 
   push:
     needs: test

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,12 +1,10 @@
 ﻿$packageName    = 'podman-cli'
-$url_amd64      = 'https://github.com/containers/podman/releases/download/v5.8.0/podman-remote-release-windows_amd64.zip'
-$url_arm64      = 'https://github.com/containers/podman/releases/download/v5.8.0/podman-remote-release-windows_arm64.zip'
-$checksum_amd64 = '5d88d730f9963c3cfabae4c8e688a025f59cd5ff045878506e3955b004eeb522'
-$checksum_arm64 = '43608836a0e9977acc0316dbd180fef68779d308aff21bd34ae91f01e9984041'
+$url_amd64      = 'https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi'
+$url_arm64      = 'https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-arm64.msi'
+$checksum_amd64 = 'eda54f26f9695d198d9a679fa45ae24ba35b78444f432b5fe0c122c5a3624c57'
+$checksum_arm64 = '77e9810e7598ef588b1fe7a850bf6baf572b30545dde82879a31638708c97bcd'
 $checksumType   = 'sha256'
 $validExitCodes = @(0)
- 
-$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $os = Get-WmiObject -Class Win32_OperatingSystem
 if ($os.OSArchitecture -like "*ARM*") {
@@ -17,9 +15,14 @@ if ($os.OSArchitecture -like "*ARM*") {
     $checksum = $checksum_amd64
 }
 
-Install-ChocolateyZipPackage `
-  -PackageName $packageName `
-  -Url64bit "$url" `
-  -UnzipLocation "$toolsDir" `
-  -Checksum64 $checksum `
-  -ChecksumType64 $checksumType
+$packageArgs = @{
+  packageName   = $packageName
+  fileType      = 'MSI'
+  url64bit      = $url
+  checksum64    = $checksum
+  checksumType64= $checksumType
+  silentArgs    = "/qn /norestart"
+  validExitCodes= $validExitCodes
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Hi, Podman maintainer here. 

Starting with Podman v6.0, we will stop releasing old installers (which required admin privileges), and we suggest that adopters use the new MSI package before the release.

The new MSI package has been released since 5.7, and it can be installed at the user-scope as well as the machine-scope.

More details here https://github.com/containers/podman/issues/27625